### PR TITLE
Feature/test unit profile model

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -5,9 +5,11 @@ class Profile < ApplicationRecord
   validates :user_id, uniqueness: true
 
   with_options presence: true do
+    validates :image
     validates :name
     validates :store_name
-    validates :store_url
+    VALID_URL_REGEX = /\A#{URI::regexp(%w(http https))}\z/.freeze
+    validates :store_url, format: { with: VALID_URL_REGEX }
     validates :text
   end
-end
+end 

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,5 +1,6 @@
-<%= form_with model: @profile, url: profiles_path do |f| %>
+<%= form_with model: @profile, url: profiles_path, local: true do |f| %>
   <%= link_to "YouMe", root_path, class: "navbar-brand" %>
+  <%= render 'shared/error_messages', model: f.object %>
 
   <h4>あなたを教えてください</h4>
 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div class="error-alert">
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+      <li class='error-message'><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -26,7 +26,7 @@ ja:
         unlock_token: ロック解除用トークン
         updated_at: 更新日
     models:
-      user: ユーザ
+      user: ユーザー
   devise:
     confirmations:
       confirmed: メールアドレスが確認できました。
@@ -39,10 +39,10 @@ ja:
       inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
       invalid: "%{authentication_keys}またはパスワードが違います。"
       last_attempt: もう一回誤るとアカウントがロックされます。
-      locked: アカウントは凍結されています。
+      locked: アカウントはロックされています。
       not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
       timeout: セッションがタイムアウトしました。もう一度ログインしてください。
-      unauthenticated: 新規登録もしくはログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
       unconfirmed: メールアドレスの本人確認が必要です。
     mailer:
       confirmation_instructions:
@@ -52,11 +52,12 @@ ja:
         subject: メールアドレス確認メール
       email_changed:
         greeting: こんにちは、%{recipient}様。
-        message: あなたのメール変更（%{email}）のお知らせいたします。
-        subject: メール変更完了。
+        message: あなたのメールの変更（%{email}）をお知らせいたします。
+        message_unconfirmed:
+        subject: メール変更完了
       password_change:
         greeting: "%{recipient}様"
-        message: パスワードが再設定されたことを通知します。
+        message: パスワードが再設定されました。
         subject: パスワードの変更について
       reset_password_instructions:
         action: パスワード変更
@@ -70,7 +71,7 @@ ja:
         greeting: "%{recipient}様"
         instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
         message: ログイン失敗が繰り返されたため、アカウントはロックされています。
-        subject: アカウントの凍結解除について
+        subject: アカウントのロック解除について
     omniauth_callbacks:
       failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
       success: "%{kind} アカウントによる認証に成功しました。"
@@ -81,7 +82,7 @@ ja:
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
       new:
-        forgot_your_password: パスワードを忘れましたか?
+        forgot_your_password: パスワードを忘れましたか？
         send_me_reset_password_instructions: パスワードの再設定方法を送信する
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
@@ -91,7 +92,7 @@ ja:
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。
       edit:
-        are_you_sure: 本当によろしいですか?
+        are_you_sure: 本当によろしいですか？
         cancel_my_account: アカウント削除
         currently_waiting_confirmation_for_email: "%{email} の確認待ち"
         leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
@@ -100,10 +101,10 @@ ja:
         update: 更新
         we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
       new:
-        sign_up: 新規登録
-      signed_up: 新規登録が完了しました。
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
       signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
-      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
       signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
       update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
       updated: アカウント情報を変更しました。
@@ -117,26 +118,26 @@ ja:
     shared:
       links:
         back: 戻る
-        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
-        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
-        forgot_your_password: パスワードを忘れましたか?
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
         sign_in: ログイン
         sign_in_with_provider: "%{provider}でログイン"
-        sign_up: 新規登録
+        sign_up: アカウント登録
       minimum_password_length: "（%{count}字以上）"
     unlocks:
       new:
-        resend_unlock_instructions: アカウントの凍結解除方法を再送する
-      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
-      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
-      unlocked: アカウントを凍結解除しました。
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
   errors:
     messages:
       already_confirmed: は既に登録済みです。ログインしてください。
       confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
       expired: の有効期限が切れました。新しくリクエストしてください。
       not_found: は見つかりませんでした。
-      not_locked: は凍結されていません。
+      not_locked: はロックされていません。
       not_saved:
         one: エラーが発生したため %{resource} は保存されませんでした。
         other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,19 @@
+ja:
+
+ activerecord:
+
+   attributes:
+
+     profile:
+
+       image: 画像
+
+       name: お名前
+
+       store_name: お店の名前
+
+       store_url: お店のURL
+
+       text: 自己紹介
+
+       

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,5 +1,14 @@
 FactoryBot.define do
   factory :profile do
-    
+    name       { "佐藤ましろ" }
+    store_name { "イタリアン 〜mashiro〜" }
+    store_url  { "https://example.com" }
+    text       { "心よりお待ちしております。" }
+
+    association :user
+
+    after(:build) do |profile|
+      profile.image.attach(io: File.open('app/assets/images/camera.png'), filename: 'camera.png')
+    end
   end
 end

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,5 +1,69 @@
 require 'rails_helper'
 
 RSpec.describe Profile, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before do
+    @profile = FactoryBot.build(:profile)
+  end
+  
+
+  describe "プロフィール登録" do
+    context "成功する場合" do
+      it "記入欄全てに正しい値が存在する" do
+        expect(@profile).to be_valid
+      end
+    end
+  
+  
+
+    context "失敗する場合" do
+      it "画像が添付されていない" do
+        @profile.image = nil
+        @profile.valid?
+        expect(@profile.errors.full_messages).to include("画像を入力してください")
+      end
+
+    
+      it "ユーザーの名前が空欄" do
+        @profile.name = nil
+        @profile.valid?
+        expect(@profile.errors.full_messages).to include("お名前を入力してください")
+      end
+    
+
+      it "お店の名前が空欄" do
+        @profile.store_name = nil
+        @profile.valid?
+        expect(@profile.errors.full_messages).to include("お店の名前を入力してください")
+      end
+    
+
+      it "お店のURLが空欄" do
+        @profile.store_url = nil
+        @profile.valid?
+        expect(@profile.errors.full_messages).to include("お店のURLを入力してください")
+      end
+    
+
+      it "お店のURLに(http https)のどちらも含まれていない" do
+        @profile.store_url = "example.com"
+        @profile.valid?
+        expect(@profile.errors.full_messages).to include("お店のURLは不正な値です")
+      end
+
+
+      it "お店のURLの(http https)が最初に含まれていない" do
+        @profile.store_url = "example.com//https"
+        @profile.valid?
+        expect(@profile.errors.full_messages).to include("お店のURLは不正な値です")
+      end
+    
+
+      it "自己紹介が空欄" do
+        @profile.text = nil
+        @profile.valid?
+        expect(@profile.errors.full_messages).to include("自己紹介を入力してください")
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
#目的
下記を確認する↓
ユーザーが不適切な入力内容でプロフィールを登録しようとした場合、登録が行われず、エラーメッセージを返す。


#内容
profileモデルのバリデーションが正しく動作しているか確認する。
・エラーメッセージの表示
・エラーメッセージの日本語化
・プロフィールモデルにバリデーション設定
・プロフィールモデルの単体テスト